### PR TITLE
api: refactor C API's json input interface

### DIFF
--- a/api/code/ac/api-c.cpp
+++ b/api/code/ac/api-c.cpp
@@ -43,7 +43,7 @@ void ac_free_model(ac_model* m) {
     delete m;
 }
 
-void ac_create_model_json_params(
+void ac_create_model(
     ac_api_provider* p,
     const char* model_id,
     ac_dict_root* dict_root,
@@ -73,7 +73,7 @@ void ac_free_instance(ac_instance* i) {
     delete i;
 }
 
-void ac_create_instance_json_params(
+void ac_create_instance(
     ac_model* m,
     const char* instance_type,
     ac_dict_root* dict_root,
@@ -98,7 +98,7 @@ void ac_create_instance_json_params(
     });
 }
 
-void ac_run_op_json_params(
+void ac_run_op(
     ac_instance* i,
     const char* op,
     ac_dict_root* dict_root,

--- a/api/code/ac/api.h
+++ b/api/code/ac/api.h
@@ -10,7 +10,7 @@
 // functions implemented in c-api.cpp
 
 // general rules:
-// the ownership of dict_root is transferred to the underlying C++ code
+// the ownership of dict_root is transferred to function
 // the result_cb will be called with an error message if there is an error (and the payload will be null)
 // progress_cb can be null
 
@@ -23,7 +23,7 @@ AC_API_EXPORT void ac_free_api_provider(ac_api_provider* p);
 
 typedef struct ac_model ac_model;
 AC_API_EXPORT void ac_free_model(ac_model* m);
-AC_API_EXPORT void ac_create_model_json_params(
+AC_API_EXPORT void ac_create_model(
     ac_api_provider* p,
     const char* model_id,
     ac_dict_root* dict_root,
@@ -34,7 +34,7 @@ AC_API_EXPORT void ac_create_model_json_params(
 
 typedef struct ac_instance ac_instance;
 AC_API_EXPORT void ac_free_instance(ac_instance* i);
-AC_API_EXPORT void ac_create_instance_json_params(
+AC_API_EXPORT void ac_create_instance(
     ac_model* m,
     const char* instance_type,
     ac_dict_root* dict_root,
@@ -43,7 +43,7 @@ AC_API_EXPORT void ac_create_instance_json_params(
     void* cb_user_data
 );
 
-AC_API_EXPORT void ac_run_op_json_params(
+AC_API_EXPORT void ac_run_op(
     ac_instance* i,
     const char* op,
     ac_dict_root* dict_root,

--- a/api/test/t-wrapper.c
+++ b/api/test/t-wrapper.c
@@ -81,7 +81,7 @@ void dummy_provider(void) {
     CHECK_NOT_NULL(provider);
 
     state s = {0};
-    ac_create_model_json_params(
+    ac_create_model(
         provider, "error", 
         ac_dict_new_root_from_json("{\"error\": true}", NULL), 
         on_model_result, on_progress, &s
@@ -91,7 +91,7 @@ void dummy_provider(void) {
     CHECK_CLOSE(1e-5, 0.2, s.last_progress);
     s.last_progress = 0;
 
-    ac_create_model_json_params(
+    ac_create_model(
         provider, "model",
         ac_dict_new_root_from_json("{\"error\": true}", NULL),
         on_model_result, on_progress, &s
@@ -100,15 +100,15 @@ void dummy_provider(void) {
     CHECK_NULL(s.model);
     s.last_progress = 0;
 
-    ac_create_model_json_params(
+    ac_create_model(
         provider, "model",
-        ac_dict_new_root_from_json("{}", NULL),
+        NULL,
         on_model_result, on_progress, &s
     );
     CHECK_EQ_STR("", s.last_error);
     CHECK_NOT_NULL(s.model);
 
-    ac_create_instance_json_params(
+    ac_create_instance(
         s.model, "error",
         ac_dict_new_root_from_json("{\"error\": \"bad inst\"}", NULL),
         on_instance_result, on_progress, &s
@@ -117,15 +117,15 @@ void dummy_provider(void) {
     CHECK_NULL(s.instance);
     s.last_progress = 0;
 
-    ac_create_instance_json_params(
+    ac_create_instance(
         s.model, "insta", 
-        ac_dict_new_root_from_json("{}", NULL),
+        NULL,
         on_instance_result, on_progress, &s
     );
     CHECK_EQ_STR("", s.last_error);
     CHECK_NOT_NULL(s.instance);
 
-    ac_run_op_json_params(
+    ac_run_op(
         s.instance, "error",
         ac_dict_new_root_from_json("{\"error\": \"bad op\"}", NULL),
         on_op_result, on_op_stream, &s
@@ -137,7 +137,7 @@ void dummy_provider(void) {
     CHECK_EQ(ac_dict_value_type_number_int, ac_dict_get_type(some));
     CHECK_EQ(42, ac_dict_get_int_value(some));
 
-    ac_run_op_json_params(
+    ac_run_op(
         s.instance, "op",
         ac_dict_new_root_from_json("{}", NULL),
         on_op_result, on_op_stream, &s
@@ -149,7 +149,11 @@ void dummy_provider(void) {
     CHECK_EQ(ac_dict_value_type_number_int, ac_dict_get_type(more));
     CHECK_EQ(1024, ac_dict_get_int_value(more));
 
-    ac_run_op_json_params(
+    // expect the same behavior with param
+    // dict_root = ac_dict_new_root_from_json("{}", NULL) 
+    // AND 
+    // dict_root = NULL
+    ac_run_op(
         s.instance, "op",
         NULL,
         on_op_result, on_op_stream, &s
@@ -161,7 +165,7 @@ void dummy_provider(void) {
     CHECK_EQ(ac_dict_value_type_number_int, ac_dict_get_type(more));
     CHECK_EQ(1024, ac_dict_get_int_value(more));
 
-    ac_run_op_json_params(
+    ac_run_op(
         s.instance, "insta",
         ac_dict_new_root_from_json("{}", NULL),
         on_op_result, on_op_stream, &s
@@ -169,18 +173,6 @@ void dummy_provider(void) {
     CHECK_EQ_STR("", s.last_error);
     CHECK_EQ_FLT(0, s.last_progress);
     ac_dict_ref insta = ac_dict_at_key(s.dict, "insta");
-    CHECK_NOT_NULL(insta);
-    CHECK_EQ(ac_dict_value_type_string, ac_dict_get_type(insta));
-    CHECK_EQ_STR("success", ac_dict_get_string_value(insta));
-
-    ac_run_op_json_params(
-        s.instance, "insta",
-        NULL,
-        on_op_result, on_op_stream, &s
-    );
-    CHECK_EQ_STR("", s.last_error);
-    CHECK_EQ_FLT(0, s.last_progress);
-    insta = ac_dict_at_key(s.dict, "insta");
     CHECK_NOT_NULL(insta);
     CHECK_EQ(ac_dict_value_type_string, ac_dict_get_type(insta));
     CHECK_EQ_STR("success", ac_dict_get_string_value(insta));

--- a/inference/llama.cpp/local/example/e-local-llama.c
+++ b/inference/llama.cpp/local/example/e-local-llama.c
@@ -109,10 +109,10 @@ int main(void) {
     );
 
     printf("Loading model...\n");
-    ac_create_model_json_params(
+    ac_create_model(
         local_provider,
         "gpt2",
-        ac_dict_new_root_from_json("{}", NULL), 
+        NULL, 
         on_model_result,
         on_progress,
         &state
@@ -124,10 +124,10 @@ int main(void) {
     }
 
     printf("Creating instance...\n");
-    ac_create_instance_json_params(
+    ac_create_instance(
         state.model,
         "general",
-        ac_dict_new_root_from_json("{}", NULL),
+        NULL,
         on_instance_result,
         on_progress,
         &state
@@ -141,7 +141,7 @@ int main(void) {
 #define PROMPT "He was slow to"
     printf("Running op. Prompt: %s\n", PROMPT);
     printf("Generation: ");
-    ac_run_op_json_params(
+    ac_run_op(
         state.instance,
         "run",
         ac_dict_new_root_from_json("{\"prompt\": \"" PROMPT "\", \"max_tokens\": 20}", NULL),

--- a/local-provider/test/t-local-provider.c
+++ b/local-provider/test/t-local-provider.c
@@ -98,7 +98,7 @@ void dummy_provider(void) {
     atomic_init(&s.cur_step_done, false);
 
     {
-        ac_create_model_json_params(
+        ac_create_model(
             provider, "error",
             ac_dict_new_root_from_json("{}", NULL),
             on_model_result, on_progress, &s
@@ -116,7 +116,7 @@ void dummy_provider(void) {
     // AND 
     // dict_root = NULL
     {
-        ac_create_model_json_params(
+        ac_create_model(
             provider, "error",
             NULL,
             on_model_result, on_progress, &s
@@ -130,7 +130,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_create_model_json_params(
+        ac_create_model(
             provider, "empty",
             ac_dict_new_root_from_json("{\"type\": \"dummy\", \"error\": true}", NULL),
             on_model_result, on_progress, &s
@@ -144,7 +144,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_create_model_json_params(
+        ac_create_model(
             provider, "model",
             ac_dict_new_root_from_json("{\"error\": true}", NULL),
             on_model_result, on_progress, &s
@@ -158,19 +158,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_create_model_json_params(
-            provider, "empty",
-            ac_dict_new_root_from_json("{}", NULL),
-            on_model_result, on_progress, &s
-        );
-        wait_for_cur_step(&s);
-
-        CHECK_EQ_STR("[json.exception.out_of_range.403] key 'type' not found", s.last_error);
-        CHECK_NULL(s.model);
-    }
-
-    {
-        ac_create_model_json_params(
+        ac_create_model(
             provider, "empty",
             NULL,
             on_model_result, on_progress, &s
@@ -184,9 +172,9 @@ void dummy_provider(void) {
 
     // note: create model with id "model" - successfully
     {
-        ac_create_model_json_params(
+        ac_create_model(
             provider, "model",
-            ac_dict_new_root_from_json("{}", NULL),
+            NULL,
             on_model_result, on_progress, &s
         );
         wait_for_cur_step(&s);
@@ -196,7 +184,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_create_instance_json_params(
+        ac_create_instance(
             s.model, "error",
             ac_dict_new_root_from_json("{\"error\": \"bad inst\"}", NULL),
             on_instance_result, on_progress, &s
@@ -208,7 +196,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_create_instance_json_params(
+        ac_create_instance(
             s.model, "error",
             ac_dict_new_root_from_json("{\"error\": true}", NULL),
             on_instance_result, on_progress, &s
@@ -221,9 +209,9 @@ void dummy_provider(void) {
 
     // note: create model with id "insta" - successfully
     {
-        ac_create_instance_json_params(
+        ac_create_instance(
             s.model, "insta", 
-            ac_dict_new_root_from_json("{}", NULL), 
+            NULL, 
             on_instance_result, on_progress, &s
         );
         wait_for_cur_step(&s);
@@ -233,7 +221,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_run_op_json_params(
+        ac_run_op(
             s.instance, "op", 
             ac_dict_new_root_from_json("{}", NULL), 
             on_op_result, on_op_stream, &s
@@ -246,8 +234,12 @@ void dummy_provider(void) {
         CHECK_EQ(42, ac_dict_get_int_value(some));
     }
 
+    // expect the same behavior with param
+    // dict_root = ac_dict_new_root_from_json("{}", NULL) 
+    // AND 
+    // dict_root = NULL
     {
-        ac_run_op_json_params(
+        ac_run_op(
             s.instance, "op", 
             NULL, 
             on_op_result, on_op_stream, &s
@@ -261,7 +253,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_run_op_json_params(
+        ac_run_op(
             s.instance, "error", 
             ac_dict_new_root_from_json("{\"error\": \"bad op\"}", NULL), 
             on_op_result, on_op_stream, &s
@@ -275,21 +267,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_run_op_json_params(
-            s.instance, "more",
-            ac_dict_new_root_from_json("{}", NULL), 
-            on_op_result, on_op_stream, &s
-        );
-        ac_synchronize_instance(s.instance);
-
-        ac_dict_ref more = ac_dict_at_key(s.dict, "more");
-        CHECK_NOT_NULL(more);
-        CHECK_EQ(ac_dict_value_type_number_int, ac_dict_get_type(more));
-        CHECK_EQ(1024, ac_dict_get_int_value(more));
-    }
-
-    {
-        ac_run_op_json_params(
+        ac_run_op(
             s.instance, "more",
             NULL, 
             on_op_result, on_op_stream, &s
@@ -303,21 +281,7 @@ void dummy_provider(void) {
     }
 
     {
-        ac_run_op_json_params(
-            s.instance, "insta", 
-            ac_dict_new_root_from_json("{}", NULL), 
-            on_op_result, on_op_stream, &s
-        );
-        ac_synchronize_instance(s.instance);
-
-        ac_dict_ref insta = ac_dict_at_key(s.dict, "insta");
-        CHECK_NOT_NULL(insta);
-        CHECK_EQ(ac_dict_value_type_string, ac_dict_get_type(insta));
-        CHECK_EQ_STR("success", ac_dict_get_string_value(insta));
-    }
-
-    {
-        ac_run_op_json_params(
+        ac_run_op(
             s.instance, "insta", 
             NULL, 
             on_op_result, on_op_stream, &s


### PR DESCRIPTION
- prefer `ac_dict_root` over plain json strings in the C API

ref: #49