### PR TITLE
Add an issue template for a user story

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -1,0 +1,31 @@
+---
+name: User Story
+about: Create a user story to help us understand a feature from the user's perspective
+title: 'As a [type of user], I want [an action] so that [a benefit/a value]'
+labels: 'user story'
+assignees: ''
+
+---
+
+## User Story
+As a [type of user], I want [an action] so that [a benefit/a value]
+
+## Acceptance Criteria
+
+(Write here concrete technical requirements which need to be met in order to consider the user story done)
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Additional Context
+Add any other context or screenshots about the feature request here.
+
+## Definition of Done
+
+- [ ] Code changes implemented
+- [ ] Unit tests written and passing
+- [ ] Integration tests passing
+- [ ] Documentation updated
+- [ ] Code reviewed and approved
+- [ ] Feature deployed to staging environment
+- [ ] Product Owner sign-off


### PR DESCRIPTION
It looks like we can add issue templates for specific types of issues. I'm testing this functionality with adding an issue template for user stories. Then I'll try to add the user stories that we need to finis for the MVP.

The Definition of Done section needs work. We need to decide what should go there. It's supposed to be the same for each user story.

This is how the "New Issue" page will look after we add this template:

![Screenshot 2024-09-18 at 11 45 34](https://github.com/user-attachments/assets/a4dfeb27-683f-416c-a407-0229d16f2542)
