### PR TITLE
whisper: Remove check for empty input

### DIFF
--- a/inference/whisper/code/ac/whisper/Instance.cpp
+++ b/inference/whisper/code/ac/whisper/Instance.cpp
@@ -48,11 +48,6 @@ Instance::Instance(Model& model, InitParams params)
 Instance::~Instance() = default;
 
 std::string Instance::transcribe(std::span<const float> pcmf32) {
-    if (pcmf32.empty()) {
-        // TODO: Investigate why whisper.cpp crashes if the input is empty #65
-        return std::string();
-    }
-
     return runInference(pcmf32);
 }
 


### PR DESCRIPTION
After `Whisper.cpp` submodule was updated the crash from #65 was no longer reproducible. We should leave the validation of the input data to the library.

closes #65